### PR TITLE
Fire iconPickerSelect on start.

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "description": "Icon picker widget for Angular (version 2 and newer)",
   "bugs": "https://github.com/tech-advantage/ngx-icon-picker/issues",
   "license": "MIT",
-  "version": "0.0.5",
+  "version": "0.0.5-1",
   "main": "bundles/ngx-icon-picker.umd.js",
   "module": "./dist/index.js",
   "typings": "./dist/index.d.ts",

--- a/src/lib/icon-picker.directive.ts
+++ b/src/lib/icon-picker.directive.ts
@@ -41,6 +41,7 @@ export class IconPickerDirective implements OnInit, OnChanges {
 
   ngOnInit() {
     this.iconPicker = this.iconPicker || this.ipFallbackIcon || 'fa fa-user-plus';
+    this.iconPickerSelect.emit(this.iconPicker);
   }
 
   onClick() {


### PR DESCRIPTION
In the `ngOnInit` method of the icon picker directive, fire output `iconPickerSelect`.
The goal is to have an icon displayed on component start.