### PR TITLE
Enabling compatibility with new @fortawesome/angular-fontawesome library versions

### DIFF
--- a/projects/lib/package.json
+++ b/projects/lib/package.json
@@ -7,7 +7,7 @@
   "peerDependencies": {
     "@angular/common": "13 - 15",
     "@angular/core": "13 - 15",
-    "@fortawesome/angular-fontawesome": "^0.10.2",
+    "@fortawesome/angular-fontawesome": ">=0.10.2",
     "@fortawesome/fontawesome-svg-core": "^6.1.1",
     "@fortawesome/free-solid-svg-icons": "^6.1.1",
     "primeicons": "^5.0.0"


### PR DESCRIPTION
Hi,

I'm getting the below error when I'm using the latest version of the `@fortawesome/angular-fontawesome` library.

```powershell
npm ERR! Found: @fortawesome/angular-fontawesome@0.12.1
npm ERR! node_modules/@fortawesome/angular-fontawesome
npm ERR!   @fortawesome/angular-fontawesome@"^0.12.1" from the root project
npm ERR! 
npm ERR! Could not resolve dependency:
npm ERR! peer @fortawesome/angular-fontawesome@"^0.10.2" from ngx-icon-picker@1.10.0
npm ERR! node_modules/ngx-icon-picker
npm ERR!   ngx-icon-picker@"^1.10.0" from the root project
```

So, I'm enabling compatibility with new versions of the `@fortawesome/angular-fontawesome` library in this PR.

Thank you,
Rodrigo Kamada