### PR TITLE
Allow higher version of primeicons

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ngx-icon-picker",
-  "description": "Icon picker widget for Angular (version 16 and newer)",
-  "bugs": "https://github.com/tech-advantage/ngx-icon-picker/issues",
+  "description": "Icon picker widget for Angular (version 16 and newer) forked by Inimco and updated to allow newer versions of primeicons",
+  "bugs": "https://github.com/Inimco/inimco-ngx-icon-picker/issues",
   "license": "MIT",
   "version": "1.11.2",
   "scripts": {
@@ -16,7 +16,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/tech-advantage/ngx-icon-picker.git"
+    "url": "git+https://github.com/Inimco/inimco-ngx-icon-picker.git"
   },
   "dependencies": {
     "@angular/animations": "^16.0.0",
@@ -33,8 +33,8 @@
     "@fortawesome/free-solid-svg-icons": "^6.1.1",
     "bootstrap": "~4.0.0",
     "ngx-bootstrap": "^11.0.0",
-    "ngx-icon-picker": "file:",
-    "primeicons": "^5.0.0",
+    "inimco-ngx-icon-picker": "file:",
+    "primeicons": ">=5.0.0",
     "rxjs": "^7.4.0",
     "tslib": "^2.0.0",
     "zone.js": "~0.13.0"
@@ -71,5 +71,10 @@
     "protractor": "~7.0.0",
     "ts-node": "~8.3.0",
     "typescript": "~4.9.3"
+  },
+  "homepage": "https://github.com/Inimco/inimco-ngx-icon-picker#readme",
+  "main": "index.js",
+  "directories": {
+    "doc": "doc"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ngx-icon-picker",
-  "description": "Icon picker widget for Angular (version 16 and newer) forked by Inimco and updated to allow newer versions of primeicons",
-  "bugs": "https://github.com/Inimco/inimco-ngx-icon-picker/issues",
+  "description": "Icon picker widget for Angular (version 16 and newer)",
+  "bugs": "https://github.com/tech-advantage/ngx-icon-picker/issues",
   "license": "MIT",
   "version": "1.11.2",
   "scripts": {
@@ -16,7 +16,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/Inimco/inimco-ngx-icon-picker.git"
+    "url": "https://github.com/tech-advantage/ngx-icon-picker.git"
   },
   "dependencies": {
     "@angular/animations": "^16.0.0",
@@ -33,8 +33,8 @@
     "@fortawesome/free-solid-svg-icons": "^6.1.1",
     "bootstrap": "~4.0.0",
     "ngx-bootstrap": "^11.0.0",
-    "inimco-ngx-icon-picker": "file:",
-    "primeicons": ">=5.0.0",
+    "ngx-icon-picker": "file:",
+    "primeicons": "^5.0.0 | ^6.0.0",
     "rxjs": "^7.4.0",
     "tslib": "^2.0.0",
     "zone.js": "~0.13.0"
@@ -71,10 +71,5 @@
     "protractor": "~7.0.0",
     "ts-node": "~8.3.0",
     "typescript": "~4.9.3"
-  },
-  "homepage": "https://github.com/Inimco/inimco-ngx-icon-picker#readme",
-  "main": "index.js",
-  "directories": {
-    "doc": "doc"
   }
 }

--- a/projects/lib/package.json
+++ b/projects/lib/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "inimco-ngx-icon-picker",
+  "name": "ngx-icon-picker",
   "version": "1.11.2",
   "dependencies": {
     "tslib": "^2.0.0"
@@ -10,6 +10,6 @@
     "@fortawesome/angular-fontawesome": ">=0.10.2",
     "@fortawesome/fontawesome-svg-core": "^6.1.1",
     "@fortawesome/free-solid-svg-icons": "^6.1.1",
-    "primeicons": ">=5.0.0"
+    "primeicons": "^5.0.0 | ^6.0.0"
   }
 }

--- a/projects/lib/package.json
+++ b/projects/lib/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "ngx-icon-picker",
+  "name": "inimco-ngx-icon-picker",
   "version": "1.11.2",
   "dependencies": {
     "tslib": "^2.0.0"
@@ -10,6 +10,6 @@
     "@fortawesome/angular-fontawesome": ">=0.10.2",
     "@fortawesome/fontawesome-svg-core": "^6.1.1",
     "@fortawesome/free-solid-svg-icons": "^6.1.1",
-    "primeicons": "^5.0.0"
+    "primeicons": ">=5.0.0"
   }
 }


### PR DESCRIPTION
We currently use primeicons 6.0.0 in our project.
Is it possible to update the icon picker so we don't have a conflicting peer dependency anymore?

Thank you for maintaining the library!